### PR TITLE
Prevent static seeds from producing same prompts.

### DIFF
--- a/scripts/wildcards.py
+++ b/scripts/wildcards.py
@@ -34,8 +34,11 @@ class WildcardsScript(scripts.Script):
         original_prompt = p.all_prompts[0]
 
         for i in range(len(p.all_prompts)):
-            random.seed(p.all_seeds[0 if shared.opts.wildcards_same_seed else i])
-
+            if shared.opts.wildcards_same_seed:
+                random.seed(p.all_seeds[0])
+            else:
+                random.seed(a=None, version=2)
+                
             prompt = p.all_prompts[i]
             prompt = "".join(self.replace_wildcard(chunk) for chunk in prompt.split("__"))
             p.all_prompts[i] = prompt


### PR DESCRIPTION
By using p.all_seeds[i] as the seed for random.choice it turns static generation seeds in to the functional equivalent of the 'Use same seed for all images' option. This rectifies that by getting a random seed from the system.