### PR TITLE
allow wildcard files to have comment lines

### DIFF
--- a/scripts/wildcards.py
+++ b/scripts/wildcards.py
@@ -24,7 +24,9 @@ class WildcardsScript(scripts.Script):
         replacement_file = os.path.join(wildcards_dir, f"{text}.txt")
         if os.path.exists(replacement_file):
             with open(replacement_file, encoding="utf8") as f:
-                return gen.choice(f.read().splitlines())
+                choices = f.read().splitlines()
+                choices = [x for x in choices if not x.startswith("#")]
+                return gen.choice(choices)
         else:
             if replacement_file not in warned_about_files:
                 print(f"File {replacement_file} not found for the __{text}__ wildcard.", file=sys.stderr)


### PR DESCRIPTION
This PR allows very simple comments in Wildcards files: if lines start with "#", they are a comment.

Having comments allows wildcard files shared between people to contain authorship information, sources, and other information.

Beyond wanting this on general principle, I personally want it for compatibility:

I'll be releasing my extended wildcards extension at some point, and it will include a number of built-in public domain wildcard lists. Because my library supports comments, I have information in them like:
```
# cc0. derived from https://github.com/dariusk/corpora
# validated in SD 1.5 with "a __animal__"
# excluded due to issues: gnu, musk, mustang, mole, newt, puma, silver fox, wolverine
aardvark
alligator
alpaca
antelope
ape
[etc.]
```

However, I intentionally don't use any other features not found in this Wildcards library other than these comments, so this small change will make those files compatible.