### PR TITLE
fix hr_negative_prompts, add hr infotext, add setting wildcards_write_infotext

### DIFF
--- a/scripts/wildcards.py
+++ b/scripts/wildcards.py
@@ -43,20 +43,17 @@ class WildcardsScript(scripts.Script):
 
         return res
 
-    def process(self, p):
-        original_prompt = p.all_prompts[0]
-        original_negative_prompt = p.all_negative_prompts[0]
-
-        p.all_prompts = self.replace_prompts(p.all_prompts, p.all_seeds)
-        p.all_negative_prompts = self.replace_prompts(p.all_negative_prompts, p.all_seeds)
-        if getattr(p, 'all_hr_prompts', None) is not None:
-            p.all_hr_prompts = self.replace_prompts(p.all_hr_prompts, p.all_seeds)
-
-        if original_prompt != p.all_prompts[0]:
-            p.extra_generation_params["Wildcard prompt"] = original_prompt
-
-        if original_negative_prompt != p.all_negative_prompts[0]:
-            p.extra_generation_params["Wildcard negative prompt"] = original_negative_prompt
+    def process(self, p, *args):
+        for attr, infotext_suffix in [
+            ('all_prompts', 'prompt'), ('all_negative_prompts', 'negative prompt'),
+            ('all_hr_prompts', 'hr prompt'), ('all_hr_negative_prompts', 'hr negative prompt'),
+        ]:
+            if all_original_prompts := getattr(p, attr, None):
+                setattr(p, attr, self.replace_prompts(all_original_prompts, p.all_seeds))
+                if all_original_prompts[0] != getattr(p, attr)[0]:
+                    if infotext_suffix.startswith("hr ") and p.extra_generation_params.get(f"Wildcard {infotext_suffix[3:]}", None) == all_original_prompts[0]:
+                        continue
+                    p.extra_generation_params[f"Wildcard {infotext_suffix}"] = all_original_prompts[0]
 
 
 def on_ui_settings():

--- a/scripts/wildcards.py
+++ b/scripts/wildcards.py
@@ -50,14 +50,15 @@ class WildcardsScript(scripts.Script):
         ]:
             if all_original_prompts := getattr(p, attr, None):
                 setattr(p, attr, self.replace_prompts(all_original_prompts, p.all_seeds))
-                if all_original_prompts[0] != getattr(p, attr)[0]:
+                if shared.opts.wildcards_write_infotext and all_original_prompts[0] != getattr(p, attr)[0]:
                     if infotext_suffix.startswith("hr ") and p.extra_generation_params.get(f"Wildcard {infotext_suffix[3:]}", None) == all_original_prompts[0]:
-                        continue
+                        continue  # don't overwrite original hr prompt is same as original first pass prompt
                     p.extra_generation_params[f"Wildcard {infotext_suffix}"] = all_original_prompts[0]
 
 
 def on_ui_settings():
     shared.opts.add_option("wildcards_same_seed", shared.OptionInfo(False, "Use same seed for all images", section=("wildcards", "Wildcards")))
+    shared.opts.add_option("wildcards_write_infotext", shared.OptionInfo(True, "Write original prompt to infotext", section=("wildcards", "Wildcards")).info("the original prompt before __wildcards__ are applied"))
 
 
 script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
- fix hr_negative_prompts
> you forgot about it in [enable negative prompt wildcards](https://github.com/AUTOMATIC1111/stable-diffusion-webui-wildcards/commit/d2c836bc2d40d3ad170ac7d8a91fec77e5557af6)

- add hr infotext
>  will only be written to if different from first pass

- add a setting that control if the infotext is written
> I enable it by default because it is how it is now 

![image](https://github.com/user-attachments/assets/459b966d-8f37-4a65-9a47-37570389db1e)
