### PR TITLE
Rework chunk-based replacer to work with less collision-prone pattern matching

### DIFF
--- a/scripts/wildcards.py
+++ b/scripts/wildcards.py
@@ -1,6 +1,7 @@
 import os
 import random
 import sys
+import re
 
 from modules import scripts, script_callbacks, shared
 
@@ -38,8 +39,21 @@ class WildcardsScript(scripts.Script):
         for i, text in enumerate(prompts):
             gen = random.Random()
             gen.seed(seeds[0 if shared.opts.wildcards_same_seed else i])
-
-            res.append("".join(self.replace_wildcard(chunk, gen) for chunk in text.split("__")))
+            rex = re.compile(r'\b__([^\s\r\n]+?)__\b')
+            last_index = 0
+            m = rex.finditer(text)
+            ret = ""
+            for match in m:
+                # print(match, match.span(0)[0], match.span(0)[1], match[1])
+                if(last_index<match.span(0)[0]):
+                    ret += text[last_index:match.span(0)[0]]
+                # ret += f"(replace {match[1]})"
+                ret += self.replace_wildcard(match[1], gen)
+                last_index = match.span(0)[1]
+            if(last_index<len(text)):
+                ret += text[last_index:]
+            res.append(ret)
+            # res.append("".join(self.replace_wildcard(chunk, gen) for chunk in text.split("__")))
 
         return res
 


### PR DESCRIPTION
The current "chunk" based replacer trips up on false positives: 
Imagine a LoRA has two underscores. The wildcard replacer splits up the text, gets a nonsense chunk, can't find a matching wildcard file, returns "the original text". Doesn't sound so bad, but the LoRA will now fail to load because it's missing the two underscores.

To prevent this and further complications, depending on other features, I've switched to a RegEx based approach that should more closely capture syntax representing intent to replace wildcards.

- Matches "__(wildcard)__" only if there are word boundaries around the underscores (and there is no whitespace within)
`\b__([^\s\r\n]+?)__\b`
- Only send matches to be replaced, obviously ^^
 
![image](https://github.com/user-attachments/assets/8ca0f00f-78a5-4f61-9f75-58aaad04eb50)